### PR TITLE
Add -m64 option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -Werror -O3
+CFLAGS = -Wall -Wextra -Werror -O3 -m64
 LDLIBS = -lquadmath
 
 PREFIX ?= /usr/local


### PR DESCRIPTION
Add -m64 option to generates code for the x86-64 architecture and thus it can compile in 32-bit environment.
