### PR TITLE
pytest test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,14 @@ matrix:
 script:
   make clean;
   make;
-  ./test.py;
+  pytest ./test.py;
   make clean;
 
 before_deploy:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip
   - python3 -m pip install packagecore
+  - python3 -m pip install pytest
   - packagecore -o dist/ "${TRAVIS_TAG#v}"
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
 install:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip
-  - python3 -m pip install logilab-common
-  - python3 -m pip install pytest
+  - python3 -m pip install logilab-common --user
+  - python3 -m pip install pytest --user
 script:
   - make clean; make;
   - pytest ./test.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 install:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip
-  - sudo apt-get install -qy  python-logilab-common
+  - python3 -m pip install logilab-common
   - python3 -m pip install pytest
 script:
   - make clean; make;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_deploy:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip
   - python3 -m pip install packagecore
+  - python3 -m pip install python-logilab-common
   - python3 -m pip install pytest
   - packagecore -o dist/ "${TRAVIS_TAG#v}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,15 @@ matrix:
       compiler: gcc
 
 script:
-  make clean;
-  make;
-  pytest ./test.py;
-  make clean;
+  - make clean; make;
+  - pytest ./test.py;
+  - make clean;
 
 before_deploy:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip
+  - sudo apt-get install -qy  python-logilab-common
   - python3 -m pip install packagecore
-  - python3 -m pip install python-logilab-common
   - python3 -m pip install pytest
   - packagecore -o dist/ "${TRAVIS_TAG#v}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ matrix:
       dist: trusty
       compiler: gcc
 
+install:
+  - sudo apt-get update -qy
+  - sudo apt-get install -qy python3 python3-pip
+  - sudo apt-get install -qy  python-logilab-common
+  - python3 -m pip install pytest
 script:
   - make clean; make;
   - pytest ./test.py;
@@ -16,9 +21,7 @@ script:
 before_deploy:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip
-  - sudo apt-get install -qy  python-logilab-common
   - python3 -m pip install packagecore
-  - python3 -m pip install pytest
   - packagecore -o dist/ "${TRAVIS_TAG#v}"
 
 deploy:

--- a/test.py
+++ b/test.py
@@ -112,18 +112,12 @@ res = [
     b'ERROR: unknown unit\n',                      # 42
 ]
 
-print()
 
-for index, item in enumerate(test):
-    print('Executing test %d' % (int)(index + 1))
-
-    try:
+@pytest.mark.parametrize('item, res', zip(test, res))
+def test_output(item, res):
         out = subprocess.check_output(item, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # print(e.output)
-        assert e.output == res[index]
+        assert e.output == res
     else:
-        assert out == res[index]
-
-print('\nAll good! :)')
-sys.exit(0)
+        assert out == res

--- a/test.py
+++ b/test.py
@@ -20,6 +20,8 @@ NOTES:
 import subprocess
 import sys
 
+import pytest
+
 test = [
     ('./bcal', '-m', '10', 'mb'),                                    # 1
     ('./bcal', '-m', '10', 'TiB'),                                   # 2

--- a/test.py
+++ b/test.py
@@ -115,6 +115,7 @@ res = [
 
 @pytest.mark.parametrize('item, res', zip(test, res))
 def test_output(item, res):
+    try:
         out = subprocess.check_output(item, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # print(e.output)


### PR DESCRIPTION
~~WIP~~

- use pytest's parametrize for testing
- test index is no longer printed
- add install section on travis, it mirror some command on `before_deploy`
- install logilab-common. it is required to install pytest
- install python package with `user` flag to fix permission error
- change `script` section in travis to run pytest
- remove end test text ('all good')