### PR TITLE
fix maybe-uninitialized

### DIFF
--- a/src/bcal.c
+++ b/src/bcal.c
@@ -362,7 +362,7 @@ static maxuint_t strtouquad(char *token, char **pch)
 
 	char *ptr;
 	maxuint_t val = 0, prevval = 0;
-	uint base = 10, multiplier, digit, bits_used = 0;
+	uint base = 10, multiplier = 0, digit, bits_used = 0;
 	uint max_bit_len = sizeof(maxuint_t) << 3;
 
 	if (token[0] == '0') {


### PR DESCRIPTION
My compiler throwed the error:
```sh
gcc -Os -fomit-frame-pointer -Wall -Wextra -Wno-unused-parameter -Werror -Iinc -o bcal src/bcal.c -lreadline
src/bcal.c: In function 'strtouquad':
src/bcal.c:401:15: error: 'multiplier' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    val = (val << multiplier) + digit;
          ~~~~~^~~~~~~~~~~~~~
cc1: all warnings being treated as errors

initializing multiplier = 0 fixes the error
```