### PR TITLE
Add a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: bcal
+base: core18
+version: git
+summary: Storage and general-purpose calculator
+description: |
+  `bcal` (*Byte CALculator*) is a REPL CLI utility for storage expressions,
+  unit conversions or address calculations. If you can't calculate the hex
+  address offset for (512 - 16) MiB, or the value when the 43rd bit of a
+  64-bit address is set mentally, `bcal` is for you.
+
+grade: stable
+confinement: strict
+
+parts:
+  bcal:
+    plugin: make
+    build-packages: [clang, libreadline-dev]
+    source: .
+
+apps:
+  bcal:
+    command: usr/local/bin/bcal


### PR DESCRIPTION
Hi jarun. I saw that bcal wasn't released in the [Snap Store](https://snapcraft.io/store) so I went ahead and created a snapcraft.yaml for it. If you want to build and test this locally, run `snap install snapcraft` on Ubuntu or [install Multipass](https://github.com/CanonicalLtd/multipass/releases) and `brew install snapcraft` on MacOS.

If you release it in Snap Store, the millions of Linux users can install it with `snap install bcal` or at https://snapcraft.io/bcal, which is a bit easier than the debs and rpms on the GH releases page. If you're up for that, it shouldn't take more than a few minutes: [create an account](http://snapcraft.io/account), then:

```bash
snapcraft login
snapcraft register bcal
snapcraft push --release stable *.snap
```