### PR TITLE
Makefile portability tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ SRC = $(wildcard src/*.c)
 INCLUDE = -Iinc
 
 bcal: $(SRC)
-	$(CC) $(CFLAGS) $(INCLUDE) -o bcal $(SRC) $(LDLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(INCLUDE) -o bcal $(SRC) $(LDLIBS)
 
 all: bcal
 
 x86: $(SRC)
-	$(CC) -m64 $(CFLAGS) $(INCLUDE) -o bcal $(SRC) $(LDLIBS)
+	$(CC) -m64 $(CFLAGS) $(LDFLAGS) $(INCLUDE) -o bcal $(SRC) $(LDLIBS)
 	strip bcal
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ STRIP ?= strip
 
 CFLAGS ?= -O3
 CFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror
-LDLIBS = -lreadline
+LDLIBS += -lreadline
 
 SRC = $(wildcard src/*.c)
 INCLUDE = -Iinc

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/bcal
 STRIP ?= strip
 
-CFLAGS ?= -O3
 CFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror
 LDLIBS += -lreadline
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/bcal
 STRIP ?= strip
 
 CFLAGS_OPTIMIZATION ?= -O3
-CFLAGS_WARNINGS     ?= -Wall -Wextra -Wno-unused-paramter -Werror
+CFLAGS_WARNINGS     ?= -Wall -Wextra -Wno-unused-parameter -Werror
 
 LDLIBS_READLINE ?= -lreadline
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/bcal
 STRIP ?= strip
 
-CFLAGS += -Wall -Wextra -Wno-unused-parameter -Werror
-LDLIBS += -lreadline
+CFLAGS_OPTIMIZATION ?= -O3
+CFLAGS_WARNINGS     ?= -Wall -Wextra -Wno-unused-paramter -Werror
+
+LDLIBS_READLINE ?= -lreadline
+
+CFLAGS += $(CFLAGS_OPTIMIZATION) $(CFLAGS_WARNINGS)
+LDLIBS += $(LDLIBS_READLINE)
 
 SRC = $(wildcard src/*.c)
 INCLUDE = -Iinc


### PR DESCRIPTION
This came up creating the [pkgsrc package](http://pkgsrc.se/math/bcal) (and already part of it):

- Respect existing LDLIBS (`+=` instead of `=`)
- Respect LDFLAGS in the environment
- No `-O3` by default.

I understand the last one is debatable. It's pkgsrc policy to have the user control the optimisation level but you might feel differently and I'll happily tweak the PR to your liking.