### PR TITLE
Un-PHONY 'bcal' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,4 @@ clean:
 
 skip: ;
 
-.PHONY: bcal all x86 distclean install uninstall strip clean
+.PHONY: all x86 distclean install uninstall strip clean


### PR DESCRIPTION
With bcal marked as phony, 'make' will rebuild the bcal binary every time even if no source files changed. Phony targets are usually only used for non-file targets like 'install' and 'clean'.