### PR TITLE
Include <getopt.h>

### DIFF
--- a/src/bcal.c
+++ b/src/bcal.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <getopt.h>
 #include <readline/history.h>
 #include <readline/readline.h>
 #include "dslib.h"


### PR DESCRIPTION
This fixes the build with `-std=c23` (and `-D_POSIX_C_SOURCE` for `kill()`).